### PR TITLE
Add linux libcamera support 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ thiserror = "1.0"
 x-base = "0.1"
 x-media = "0.1"
 x-variant = "0.1"
+smallvec = "1.15.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+#libcamera 0.4.0 doesn't contain all the APIs required, we need to use a newer version from git
+#libcamera = { version = "0.4.0" }
+libcamera = { git = "https://github.com/lit-robotics/libcamera-rs.git", rev = "764c498c0eb69f3cca1954dd306408841b7171ad"}
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 av-foundation = "0.5"

--- a/examples/camera.rs
+++ b/examples/camera.rs
@@ -1,3 +1,4 @@
+use x_media::video::{PixelFormat, VideoFormat};
 use video_capture::{
     camera::CameraManager,
     device::{Device, OutputDevice},
@@ -64,6 +65,8 @@ fn main() {
     option["width"] = 1280.into();
     option["height"] = 720.into();
     option["frame-rate"] = 30.0.into();
+    option["format"] = Variant::UInt32(VideoFormat::Pixel(PixelFormat::YUYV).into());
+
     if let Err(e) = device.configure(option) {
         println!("{:?}", e.to_string());
     }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -11,6 +11,8 @@ cfg_if! {
         pub use crate::backend::media_foundation::MediaFoundationDeviceManager as DefaultCameraManager;
     } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         pub use crate::backend::av_foundation::AVFoundationCaptureDeviceManager as DefaultCameraManager;
+    } else if #[cfg(target_os = "linux")] {
+        pub use crate::backend::libcamera::LinuxCameraManager as DefaultCameraManager;
     } else {
         compile_error!("unsupported target");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ cfg_if! {
     } else if #[cfg(target_os = "windows")] {
         #[path = "windows/mod.rs"]
         pub mod backend;
+    } else if #[cfg(target_os = "linux")] {
+        #[path = "linux/mod.rs"]
+        pub mod backend;
     } else {
         compile_error!("unsupported target");
     }

--- a/src/linux/libcamera.rs
+++ b/src/linux/libcamera.rs
@@ -1,0 +1,628 @@
+//! Linux support using libcamera.
+//!
+//! libcamera cameras are different to USB web cameras in that they expose a min/max/default frame rate
+//! range, instead of a fixed set of frame rates.  This is usually because the SoC to which a MIPI
+//! camera is connected to controls the rate at which it captures images, and the min/max are based
+//! on the image sensor's capabilities.
+//!
+//! See `variable-frame-durations` in the `formats` response.
+//!
+//! Original Author: Dominic Clifton <me@dominiclifton.name>
+use libcamera::controls::ControlId;
+use std::{io, sync::Arc, thread, time::{SystemTime, UNIX_EPOCH}};
+use std::num::NonZeroU32;
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use libcamera::{
+    camera::ActiveCamera,
+    camera_manager::CameraManager,
+    framebuffer_allocator::{FrameBufferAllocator},
+    request::ReuseFlag,
+    stream::StreamRole,
+};
+use libcamera::camera::{Camera, CameraConfiguration};
+use libcamera::control_value::ControlValue;
+use libcamera::framebuffer::AsFrameBuffer;
+use libcamera::framebuffer_allocator::FrameBuffer;
+use libcamera::framebuffer_map::MemoryMappedFrameBuffer;
+use libcamera::properties::Model;
+use media::media_frame::MediaFrame;
+use media::video::{PixelFormat, VideoFormat, VideoFrameDescription};
+use crate::{
+    device::{Device, DeviceEvent, OutputDevice, DeviceManager},
+    error::DeviceError,
+    variant::Variant,
+};
+
+const PIXEL_FORMAT_NV12: libcamera::pixel_format::PixelFormat = libcamera::pixel_format::PixelFormat::new(FOURCC_NV12, 0);
+const PIXEL_FORMAT_YUYV: libcamera::pixel_format::PixelFormat = libcamera::pixel_format::PixelFormat::new(FOURCC_YUYV, 0);
+const PIXEL_FORMAT_YU12: libcamera::pixel_format::PixelFormat = libcamera::pixel_format::PixelFormat::new(FOURCC_YU12, 0);
+const FOURCC_NV12: u32 = u32::from_le_bytes([b'N', b'V', b'1', b'2']);
+const FOURCC_YUYV: u32 = u32::from_le_bytes([b'Y', b'U', b'Y', b'V']);
+const FOURCC_YU12: u32 = u32::from_le_bytes([b'Y', b'U', b'1', b'2']);
+
+type OutputHanderFn = dyn Fn(MediaFrame) -> Result<(), DeviceError> + Send + Sync;
+type OutputHandlerArc = Arc<OutputHanderFn>;
+
+struct LinuxCameraWorker {
+    pending_camera: Camera<'static>,
+    camera: Option<ActiveCamera<'static>>,
+    alloc: FrameBufferAllocator,
+    output_handler: Option<OutputHandlerArc>,
+    config: CameraConfiguration,
+    cmd_rx: mpsc::Receiver<CameraCmd>,
+    cmd_response_tx: mpsc::Sender<CameraCmdResponse>,
+
+    config_applied: bool,
+}
+
+// Safety: the `ActiveCamera` is only used by the worker thread
+unsafe impl Send for LinuxCameraWorker {}
+
+impl LinuxCameraWorker {
+    fn run(mut instance: LinuxCameraWorker) {
+
+        let mut req_rx = None;
+        let mut running = false;
+        let mut shutdown = false;
+
+        while !shutdown {
+            // process all outstanding commands
+            while let Ok(cmd) = instance.cmd_rx.try_recv() {
+                if shutdown {
+                    break;
+                }
+
+                match cmd {
+                    CameraCmd::GetFormats => {
+                        let config = instance.pending_camera.generate_configuration(&[StreamRole::ViewFinder]).unwrap();
+                        let view_finder_config = config.get(0).unwrap();
+                        let camera_formats = view_finder_config.formats();
+
+                        let controls: &libcamera::control::ControlInfoMap = instance.pending_camera.controls();
+
+                        let Ok(frame_duration_limits) = controls.find(ControlId::FrameDurationLimits.into()) else {
+                            let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::GetFailed("No 'frame duration limits' control".into())));
+                            continue
+                        };
+
+                        println!("Frame Duration. Min: {:?}, Max: {:?}, Default: {:?}",
+                            frame_duration_limits.min(),
+                            frame_duration_limits.max(),
+                            frame_duration_limits.def(),
+                        );
+
+                        // there really must be a better way of doing this...
+                        let (min, max, default) = match (frame_duration_limits.min(), frame_duration_limits.max(), frame_duration_limits.def()) {
+                            (ControlValue::Int64(min), ControlValue::Int64(max), ControlValue::Int64(default)) => (min[0], max[0], default[0]),
+                            _ => {
+                                let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::GetFailed("Unexpected types for frame duration limits".into())));
+                                continue
+                            }
+                        };
+                        let (fps_min, fps_max, fps_default) = (
+                            1_000_000_f64 / max as f64, // fps min = max interval
+                            1_000_000_f64 / min as f64, // fps max = min interval
+                            1_000_000_f64 / default as f64,
+                        );
+
+                        // now, since there is no ACTUAL fps (like you get with a USB camera) but a range instead, we have to invent some...
+                        let mut frame_rates = vec![fps_min, fps_max, fps_default];
+                        frame_rates.dedup();
+
+                        let mut variable_frame_durations = Variant::new_dict();
+                        variable_frame_durations["min"] = min.into();
+                        variable_frame_durations["max"] = max.into();
+                        variable_frame_durations["default"] = default.into();
+
+                        let mut formats = Variant::new_array();
+                        for pixel_format in camera_formats.pixel_formats().into_iter() {
+
+                            let video_format = match pixel_format.fourcc() {
+                                FOURCC_YUYV => VideoFormat::Pixel(PixelFormat::YUYV),
+                                FOURCC_YU12 => VideoFormat::Pixel(PixelFormat::YV12),
+                                FOURCC_NV12 => VideoFormat::Pixel(PixelFormat::NV12),
+                                _ => {
+                                    // TODO support more formats (Contribution/PR's welcomed)
+                                    continue
+                                }
+                            };
+
+                            let mut sizes = camera_formats.sizes(pixel_format).into_iter()
+                                .collect::<Vec<_>>();
+                            sizes.sort_by(|a,b|a.width.cmp(&b.width).then(a.height.cmp(&b.height)));
+
+                            for size in sizes {
+                                let mut format = Variant::new_dict();
+                                format["format"] = (Into::<u32>::into(video_format)).into();
+                                format["width"] = size.width.into();
+                                format["height"] = size.height.into();
+
+                                format["frame-rates"] = frame_rates.iter().map(|frame_rate| Variant::from(frame_rate.clone())).collect();
+
+                                format["variable-frame-durations"] = variable_frame_durations.clone().into();
+
+                                formats.array_add(format);
+                            }
+                        }
+
+                        let _ = instance.cmd_response_tx.send(CameraCmdResponse::Formats(formats));
+                    }
+                    CameraCmd::Start => {
+                        if running {
+                            let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::StartFailed("Already running".into())));
+                            continue
+                        }
+
+                        let active_camera = match instance.pending_camera.acquire() {
+                            Ok(camera) => camera,
+                            Err(e) => {
+                                let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::StartFailed(format!("Acqurie failed. error: {:?}", e).into())));
+                                continue
+                            }
+                        };
+
+                        let active_camera: ActiveCamera<'static> = unsafe { std::mem::transmute(active_camera) };
+
+                        instance.camera = Some(active_camera);
+
+                        if !instance.config_applied {
+                            if let Err(e) = Self::validate_and_configure(&mut instance) {
+                                let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::StartFailed(format!("Configuration failed. error: {:?}", e).into())));
+                                continue
+                            }
+                        }
+
+                        let camera = instance.camera.as_mut().unwrap();
+                        let handler = instance.output_handler.clone();
+                        let stream_cfg = instance.config
+                            .get_mut(0).unwrap();
+
+                        let stream = stream_cfg.stream().unwrap();
+
+                        let size = stream_cfg.get_size();
+                        let format: libcamera::pixel_format::PixelFormat = stream_cfg.get_pixel_format();
+
+                        // TODO support more formats (Contribution/PR's welcomed)
+                        let pixel_format = match format.fourcc() {
+                            FOURCC_NV12 => crate::media::video::PixelFormat::NV12,
+                            FOURCC_YU12 => crate::media::video::PixelFormat::YV12,
+                            FOURCC_YUYV => crate::media::video::PixelFormat::YUYV,
+                            _ => {
+
+                                let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::StartFailed(format!("Unsupported pixel format. {:?}", format).into())));
+                                continue;
+                            },
+                        };
+
+                        let desc = VideoFrameDescription::new(
+                            pixel_format,
+                            unsafe { NonZeroU32::new_unchecked(size.width) },
+                            unsafe { NonZeroU32::new_unchecked(size.height) },
+                        );
+
+                        let (req_tx, new_req_rx) = mpsc::channel::<libcamera::request::Request>();
+                        req_rx = Some(new_req_rx);
+
+                        if let Some(handler) = handler {
+                            // Set callback for completed requests
+                            camera.on_request_completed({
+                                let desc = desc.clone();
+                                move |req| {
+                                    if let Some(framebuffer) = req.buffer::<MemoryMappedFrameBuffer<FrameBuffer>>(&stream) {
+                                        if let Some(plane) = framebuffer.data().get(0) {
+                                            let bytes_used = framebuffer.planes().get(0).unwrap().len() as usize;
+                                            let data = plane[..bytes_used].to_vec();
+
+                                            let timestamp = SystemTime::now()
+                                                .duration_since(UNIX_EPOCH)
+                                                .unwrap()
+                                                .as_micros() as u64;
+
+                                            // do it conditionally to avoid configuration mismatches, shouldn't really be needed.
+                                            if let Ok(mut frame) = MediaFrame::from_data_buffer(desc.clone(), data.as_slice()) {
+                                                frame.timestamp = timestamp;
+
+                                                let _ = handler(frame);
+                                            }
+                                        }
+                                    }
+
+                                    // Reuse and requeue
+                                    req_tx.send(req).unwrap();
+                                }
+                            });
+                        }
+
+                        let buffers = instance.alloc
+                            .alloc(&stream)
+                            .unwrap()
+                            .into_iter()
+                            .map(|b| MemoryMappedFrameBuffer::new(b).unwrap())
+                            .collect::<Vec<_>>();
+
+                        let reqs = buffers
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, buf)| {
+                                let mut req = camera.create_request(Some(i as u64)).unwrap();
+                                req.add_buffer(&stream, buf).unwrap();
+                                req
+                            })
+                            .collect::<Vec<_>>();
+
+                        if let Err(e) = camera.start(None) {
+                            let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::StartFailed(format!("{e:?}"))));
+                            continue;
+                        };
+
+                        // Enqueue all requests to the camera
+                        for req in reqs {
+                            println!("Request queued for execution: {req:#?}");
+                            camera.queue_request(req).unwrap();
+                        }
+
+                        running = true;
+
+                        let _ = instance.cmd_response_tx.send(CameraCmdResponse::Ok);
+                    }
+                    CameraCmd::Stop => {
+                        let Some(mut camera) = instance.camera.take() else {
+                            let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::NotRunning("Not running".to_string())));
+                            continue;
+                        };
+
+                        if let Err(e) = camera.stop() {
+                            let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::StopFailed(format!("{e:?}"))));
+                        }
+
+                        // active camera dropped at end of scope (`ActiveCamera::Drop` impl releases it)
+
+                        running = false;
+                        let _ = instance.cmd_response_tx.send(CameraCmdResponse::Ok);
+                    }
+                    CameraCmd::Shutdown => {
+                        shutdown = true;
+                        break
+                    }
+                    CameraCmd::SetOutputHandler(handler) => {
+                        instance.output_handler = Some(handler);
+                        let _ = instance.cmd_response_tx.send(CameraCmdResponse::Ok);
+                    }
+                    CameraCmd::Configure(options) => {
+                        let mut stream_config = instance.config
+                            .get_mut(0).unwrap();
+
+                        // TODO match the options against a valid format for this device, since the supplied values may be wrong or result in an invalid combination.
+                        let desired_size = if let (Some(width), Some(height)) = (options["width"].get_uint32(), options["height"].get_uint32()) {
+                            Some(libcamera::geometry::Size { width, height })
+                        } else {
+                            None
+                        };
+
+                        if let Some(desired_size) = desired_size {
+                            println!("desired size: {:?}", desired_size);
+                            stream_config.set_size(desired_size);
+                        }
+
+                        let video_format = options["format"].get_uint32();
+
+                        let video_format = match video_format {
+                            Some(video_format) => media::video::VideoFormat::try_from(video_format).ok(),
+                            None => None,
+                        };
+
+                        println!("video format: {:?}", video_format);
+
+                        match video_format {
+                            Some(VideoFormat::Pixel(PixelFormat::NV12)) => stream_config.set_pixel_format(PIXEL_FORMAT_NV12),
+                            Some(VideoFormat::Pixel(PixelFormat::YUYV)) => stream_config.set_pixel_format(PIXEL_FORMAT_YUYV),
+                            // YV12 == YU12 ?
+                            Some(VideoFormat::Pixel(PixelFormat::YV12)) => stream_config.set_pixel_format(PIXEL_FORMAT_YU12),
+                            Some(_) => {
+                                let _ = instance.cmd_response_tx.send(CameraCmdResponse::DeviceError(DeviceError::SetFailed(format!("Unsupported format. '{:?}'", video_format))));
+                            },
+                            None => {
+                                // XXX temporarily use YUYV as default format
+                                stream_config.set_pixel_format(PIXEL_FORMAT_YUYV)
+                            }
+                        };
+
+                        let frame_rate = options["frame-rate"].get_float();
+                        if let Some(frame_rate) = frame_rate {
+                            // TODO
+                        }
+
+                        // drop the reference to avoid borrow checker issues
+                        drop(stream_config);
+
+                        // we can't actually apply the configuration until the camera is acquired
+
+                        if let Some(desired_size) = desired_size {
+                            let stream_config = instance.config
+                                .get_mut(0).unwrap();
+                            let actual_size = stream_config.get_size();
+                            assert_eq!((desired_size.width, desired_size.height), (actual_size.width, actual_size.height));
+                        }
+                        if instance.cmd_response_tx.send(CameraCmdResponse::Ok).is_err() {
+                            break
+                        }
+                    }
+                }
+            }
+            if let Some(req_rx) = req_rx.as_mut() {
+                if let Ok(mut req) = req_rx.recv_timeout(Duration::from_millis(250)) {
+                    if let Some(ref camera) = instance.camera {
+                        req.reuse(ReuseFlag::REUSE_BUFFERS);
+
+                        // TODO queue the request based on the desired frame rate / frame duration, not immediately.
+                        thread::sleep(Duration::from_secs_f64(1.0 / 30.0));
+
+                        if let Err(e) = camera.queue_request(req) {
+                            eprintln!("queue_request failed: {:?}", e);
+                            break;
+                        }
+                    } else {
+                        drop(req);
+                    }
+                }
+            }
+        }
+    }
+
+    fn validate_and_configure(instance: &mut LinuxCameraWorker) -> io::Result<()> {
+        instance.config.validate();
+        let result = instance.camera.as_mut().unwrap().configure(&mut instance.config);
+
+        // XXX
+        println!("config: {:?}", instance.config);
+
+        instance.config_applied = true;
+        result
+    }
+}
+
+enum CameraCmd
+{
+    Start,
+    Stop,
+    Shutdown,
+    SetOutputHandler(OutputHandlerArc),
+    Configure(Variant),
+    GetFormats,
+}
+
+enum CameraCmdResponse {
+    Ok,
+    DeviceError(DeviceError),
+    Formats(Variant),
+}
+
+struct LinuxCameraWorkerHandle {
+    join: JoinHandle<()>,
+}
+
+/// Linux backend device
+pub struct LinuxCameraDevice {
+    id: String,
+    name: String,
+    running: bool,
+    worker_handle: Option<LinuxCameraWorkerHandle>,
+    cmd_tx: mpsc::Sender<CameraCmd>,
+    cmd_response_rx: mpsc::Receiver<CameraCmdResponse>,
+}
+
+impl LinuxCameraDevice {
+    pub fn new(
+        camera: Camera<'static>
+    ) -> Self {
+        let id = camera.id().to_string();
+        let name = camera.properties().get::<Model>().unwrap_or(Model("N/A".to_string())).to_string();
+
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<CameraCmd>();
+        let (cmd_response_tx, cmd_response_rx) = std::sync::mpsc::channel::<CameraCmdResponse>();
+
+        let config = camera.generate_configuration(&[StreamRole::VideoRecording]).unwrap();
+        let alloc = FrameBufferAllocator::new(&camera);
+
+        let worker = LinuxCameraWorker {
+            pending_camera: camera,
+            camera: None,
+            config,
+            alloc,
+            output_handler: None,
+            cmd_rx,
+            cmd_response_tx,
+            config_applied: false,
+        };
+
+        let worker_join_handle = thread::spawn(move || { LinuxCameraWorker::run(worker)});
+
+        Self {
+            id,
+            name,
+            running: false,
+            worker_handle: Some(LinuxCameraWorkerHandle { join: worker_join_handle }),
+            cmd_tx,
+            cmd_response_rx,
+        }
+    }
+}
+
+impl Device for LinuxCameraDevice {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn start(&mut self) -> Result<(), DeviceError> {
+        self.cmd_tx.send(CameraCmd::Start)
+            .map_err(|e| DeviceError::StartFailed(format!("Failed to send start command: {:?}", e)))?;
+        match self.cmd_response_rx.recv()
+            .map_err(|e| DeviceError::StartFailed(format!("No response to command: {:?}", e)))?
+        {
+            CameraCmdResponse::Ok => Ok(()),
+            CameraCmdResponse::DeviceError(e) => Err(e),
+            _ => unreachable!(),
+        }
+    }
+
+    fn stop(&mut self) -> Result<(), DeviceError> {
+        self.cmd_tx.send(CameraCmd::Stop)
+            .map_err(|e| DeviceError::CloseFailed(format!("Failed to send close command: {:?}", e)))?;
+        match self.cmd_response_rx.recv()
+            .map_err(|e| DeviceError::StartFailed(format!("No response to command: {:?}", e)))?
+        {
+            CameraCmdResponse::Ok => Ok(()),
+            CameraCmdResponse::DeviceError(e) => Err(e),
+            _ => unreachable!(),
+        }
+    }
+
+    fn configure(&mut self, options: Variant) -> Result<(), DeviceError> {
+        self.cmd_tx.send(CameraCmd::Configure(options))
+            .map_err(|e| DeviceError::SetFailed(format!("Failed to send configure command: {:?}", e)))?;
+        match self.cmd_response_rx.recv()
+            .map_err(|e| DeviceError::SetFailed(format!("No response to command: {:?}", e)))?
+        {
+            CameraCmdResponse::Ok => Ok(()),
+            CameraCmdResponse::DeviceError(e) => Err(e),
+            _ => unreachable!(),
+        }
+    }
+
+    fn control(&mut self, _action: Variant) -> Result<(), DeviceError> {
+        // Not implemented yet
+        Ok(())
+    }
+
+    fn running(&self) -> bool {
+        self.running
+    }
+
+    fn formats(&self) -> Result<Variant, DeviceError> {
+        self.cmd_tx.send(CameraCmd::GetFormats)
+            .map_err(|e| DeviceError::SetFailed(format!("Failed to send configure command: {:?}", e)))?;
+        match self.cmd_response_rx.recv()
+            .map_err(|e| DeviceError::SetFailed(format!("No response to command: {:?}", e)))?
+        {
+            CameraCmdResponse::DeviceError(e) => Err(e),
+            CameraCmdResponse::Formats(v) => Ok(v),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Drop for LinuxCameraDevice {
+    fn drop(&mut self) {
+        let _ = self.cmd_tx.send(CameraCmd::Shutdown);
+
+        let handle = self.worker_handle.take().unwrap();
+
+        let _ = handle.join.join();
+    }
+}
+
+impl<'a> OutputDevice for LinuxCameraDevice {
+    fn set_output_handler<F>(&mut self, handler: F) -> Result<(), DeviceError>
+    where
+        F: Fn(MediaFrame) -> Result<(), DeviceError> + Send + Sync + 'static,
+    {
+        self.cmd_tx.send(CameraCmd::SetOutputHandler(Arc::new(handler)))
+            .map_err(|e| DeviceError::SetFailed(format!("Failed to send set output handler command: {:?}", e)))?;
+        match self.cmd_response_rx.recv()
+            .map_err(|e| DeviceError::SetFailed(format!("No response to command: {:?}", e)))?
+        {
+            CameraCmdResponse::Ok => Ok(()),
+            CameraCmdResponse::DeviceError(e) => Err(e),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Linux backend device manager
+pub struct LinuxCameraManager {
+    mgr: CameraManager,
+    devices: Vec<LinuxCameraDevice>,
+    change_handler: Option<Arc<dyn Fn(&DeviceEvent) + Send + Sync>>,
+}
+
+impl DeviceManager for LinuxCameraManager {
+    type DeviceType = LinuxCameraDevice;
+
+    fn init() -> Result<Self, DeviceError> {
+        let mgr = CameraManager::new()
+            .map_err(|e| DeviceError::OpenFailed(format!("{e:?}")))?;
+
+        let devices = Vec::new();
+
+        Ok(Self {
+            mgr,
+            devices,
+            change_handler: None,
+        })
+    }
+
+    fn uninit(&mut self) {
+        self.devices.clear();
+    }
+
+    fn list(&self) -> Vec<&Self::DeviceType> {
+        self.devices.iter().collect()
+    }
+
+    fn index(&self, index: usize) -> Option<&Self::DeviceType> {
+        self.devices.get(index)
+    }
+
+    fn index_mut(&mut self, index: usize) -> Option<&mut Self::DeviceType> {
+        self.devices.get_mut(index)
+    }
+
+    fn lookup(&self, id: &str) -> Option<&Self::DeviceType> {
+        self.devices.iter().find(|d| d.id() == id)
+    }
+
+    fn lookup_mut(&mut self, id: &str) -> Option<&mut Self::DeviceType> {
+        self.devices.iter_mut().find(|d| d.id() == id)
+    }
+
+    fn refresh(&mut self) -> Result<(), DeviceError> {
+
+        self.devices.clear();
+
+        let cameras = self.mgr.cameras();
+        for i in 0..cameras.len() {
+            if let Some(cam) = cameras.get(i) {
+                let cam: Camera<'static> = unsafe { std::mem::transmute(cam) };
+
+                let dev = LinuxCameraDevice::new(cam);
+                self.devices.push(dev);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_change_handler<F>(&mut self, handler: F) -> Result<(), DeviceError>
+    where
+        F: Fn(&DeviceEvent) + Send + Sync + 'static,
+    {
+        self.change_handler = Some(Arc::new(handler));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::libcamera::FOURCC_YU12;
+
+    #[test]
+    pub fn fourcc() {
+        assert_eq!(FOURCC_YU12, 0x32315559);
+    }
+}

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,0 +1,1 @@
+pub mod libcamera;


### PR DESCRIPTION
This is work-in-progress support for linux, via libcamera.

it works on a Raspberry Pi 5 with a global shutter camera.

here's a screenshot from an egui app I made to test videocapture and opencv, running on a Raspberry Pi 5 with an Raspberry Pi 5 global shutter camera.

![IMG_20251123_133154](https://github.com/user-attachments/assets/a2b4a63e-1e5f-4d08-b9ac-c16f774a40a0)

While this code works, I likely won't finish this PR branch since it seems that `media-rs` crate replaces the `x-media`, `video-capture` `x-variant` crates and allows device output handlers to receive a `Frame` instead of a `MediaFrame`, this is important because this `video-capture` crate has no way of giving output handlers compressed buffers of MJPEG images which is what most webcameras provide - only the good/expensive ones support high frame rates of uncompressed image data.

I'll make a corresponding PR in the `media-rs` crate when I've got some working code.

Since this code is unfinished, this PR just for educational / historical purposes.